### PR TITLE
added stopOnStillMinAccuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Following options are specific to provider as defined by locationProvider option
 | `fastestInterval`     | `Number`  | Android  | Fastest rate in milliseconds at which your app can handle location updates. **@see** [android  docs](https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest.html#getFastestInterval()). |
 | `activitiesInterval`  | `Number`  | Android  | Rate in milliseconds at which activity recognition occurs. Larger values will result in fewer activity detections while improving battery life.                                                                                  |
 | `stopOnStillActivity` | `Boolean` | Android  | stop() is forced, when the STILL activity is detected (default is true)                                                                                                                                                          |
+| `stopOnStillMinAccuracy` | `Number` | Android  | stop() from stopOnStillActivity is only forced, when the last location update accuracy is <= this value. "0" = disabled so stop() is always forced when STILL activity is detected (default: 0)                                                                                                                                                           |
 
 Success callback will be called with one argument - location object, which tries to mimic w3c [Coordinates interface](http://dev.w3.org/geo/api/spec-source.html#coordinates_interface).
 

--- a/android/plugin/src/main/java/com/marianhello/bgloc/ActivityRecognitionLocationProvider.java
+++ b/android/plugin/src/main/java/com/marianhello/bgloc/ActivityRecognitionLocationProvider.java
@@ -66,13 +66,25 @@ public class ActivityRecognitionLocationProvider extends AbstractLocationProvide
         log.debug("Location change: {}", location.toString());
 
         if (lastActivity.getType() == DetectedActivity.STILL) {
-            handleStationary(location);
-            stopTracking();
-            return;
-        }
 
-        if (config.isDebugging()) {
-            Toast.makeText(locationService, "acy:" + location.getAccuracy() + ",v:" + location.getSpeed() + ",df:" + config.getDistanceFilter(), Toast.LENGTH_LONG).show();
+            if ((config.getStopOnStillMinAccuracy() == 0) || (location.getAccuracy() <= config.getStopOnStillMinAccuracy())) { // stopOnStillMinAccuracy is defined && last accuracy fits
+                if (config.isDebugging()) {
+                    Toast.makeText(locationService, "STILL" + ", acc: " + location.getAccuracy(), Toast.LENGTH_SHORT).show();
+                }
+                handleStationary(location);
+                stopTracking();
+                return;
+
+            } else {    // stopOnStillMinAccuracy disabled || last accuracy to unprecise
+                if (config.isDebugging()) {
+                    Toast.makeText(locationService, "STILL" + ", acc: " + location.getAccuracy() +  " > " + config.getStopOnStillMinAccuracy()+ ", ignoreStationary", Toast.LENGTH_SHORT).show();
+                }
+            }
+
+        } else {
+            if (config.isDebugging()) {
+                Toast.makeText(locationService, "acy:" + location.getAccuracy() + ",v:" + location.getSpeed() + ",df:" + config.getDistanceFilter(), Toast.LENGTH_LONG).show();
+            }
         }
 
         // if (lastLocation != null && location.distanceTo(lastLocation) < config.getDistanceFilter()) {

--- a/android/plugin/src/main/java/com/marianhello/bgloc/Config.java
+++ b/android/plugin/src/main/java/com/marianhello/bgloc/Config.java
@@ -51,6 +51,7 @@ public class Config implements Parcelable
     private Boolean startOnBoot = false;
     private Boolean startForeground = true;
     private Boolean stopOnStillActivity = true;
+    private Integer stopOnStillMinAccuracy = 0; // 0 = disabled
     private String url;
     private String syncUrl;
     private Integer syncThreshold = 100;
@@ -83,6 +84,7 @@ public class Config implements Parcelable
         out.writeInt(getFastestInterval());
         out.writeInt(getActivitiesInterval());
         out.writeValue(getStopOnStillActivity());
+        out.writeInt(getStopOnStillMinAccuracy());
         out.writeString(getUrl());
         out.writeString(getSyncUrl());
         out.writeInt(getSyncThreshold());
@@ -121,6 +123,7 @@ public class Config implements Parcelable
         setFastestInterval(in.readInt());
         setActivitiesInterval(in.readInt());
         setStopOnStillActivity((Boolean) in.readValue(null));
+        setStopOnStillMinAccuracy(in.readInt());
         setUrl(in.readString());
         setSyncUrl(in.readString());
         setSyncThreshold(in.readInt());
@@ -263,6 +266,14 @@ public class Config implements Parcelable
         return stopOnStillActivity;
     }
 
+    public Integer getStopOnStillMinAccuracy() {
+        return stopOnStillMinAccuracy;
+    }
+
+    public void setStopOnStillMinAccuracy(Integer stopOnStillMinAccuracy) {
+        this.stopOnStillMinAccuracy = stopOnStillMinAccuracy;
+    }
+    
     public void setStopOnStillActivity(Boolean stopOnStillActivity) {
         this.stopOnStillActivity = stopOnStillActivity;
     }
@@ -341,6 +352,7 @@ public class Config implements Parcelable
                 .append(" isDebugging=").append(isDebugging())
                 .append(" stopOnTerminate=" ).append(getStopOnTerminate())
                 .append(" stopOnStillActivity=").append(getStopOnStillActivity())
+                .append(" stopOnStillMinAccuracy=").append(getStopOnStillMinAccuracy())
                 .append(" startOnBoot=").append(getStartOnBoot())
                 .append(" startForeground=").append(getStartForeground())
                 .append(" locationProvider=").append(getLocationProvider())
@@ -391,6 +403,7 @@ public class Config implements Parcelable
         config.setSmallNotificationIcon(jObject.optString("notificationIconSmall", config.getSmallNotificationIcon()));
         config.setStartForeground(jObject.optBoolean("startForeground", config.getStartForeground()));
         config.setStopOnStillActivity(jObject.optBoolean("stopOnStillActivity", config.getStopOnStillActivity()));
+        config.setStopOnStillMinAccuracy(jObject.optInt("stopOnStillMinAccuracy", config.getStopOnStillMinAccuracy()));
         config.setUrl(jObject.optString("url"));
         config.setSyncUrl(jObject.optString("syncUrl"));
         config.setSyncThreshold(jObject.optInt("syncThreshold", config.getSyncThreshold()));
@@ -419,6 +432,7 @@ public class Config implements Parcelable
         json.put("fastestInterval", getFastestInterval());
         json.put("activitiesInterval", getActivitiesInterval());
         json.put("stopOnStillActivity", getStopOnStillActivity());
+        json.put("stopOnStillMinAccuracy", getStopOnStillMinAccuracy());
         json.put("url", getUrl());
         json.put("syncUrl", getSyncUrl());
         json.put("syncThreshold", getSyncThreshold());


### PR DESCRIPTION
as described here #201 `stopOnStillMinAccuracy` is used to check if to stop on STILL activity and start stationary region handler or to keep watching for location updates until accuracy <= stopOnStillMinAccuracy.
"0" as value disables the check and stop is always forced on STILL activity.

Beware: stopOnStillMinAccuracy is currently in no way represented in location db! As I don't use that feature and don't know its inner workings I need someone else to implement it.
