### PR TITLE
fix: httpHeaders values are not sent with syncUrl on iOS

### DIFF
--- a/ios/CDVBackgroundGeolocation/LocationManager.m
+++ b/ios/CDVBackgroundGeolocation/LocationManager.m
@@ -434,7 +434,7 @@ enum {
             }
 
             NSString *syncUrl = [_config hasSyncUrl] ? _config.syncUrl : _config.url;
-            [uploader sync:syncUrl onLocationThreshold:_config.syncThreshold];
+            [uploader sync:syncUrl onLocationThreshold:_config.syncThreshold withHttpHeaders:_config.httpHeaders];
         });
     }
 

--- a/ios/CDVBackgroundGeolocation/LocationUploader.h
+++ b/ios/CDVBackgroundGeolocation/LocationUploader.h
@@ -15,7 +15,7 @@
 
 - (instancetype) init;
 - (NSString*) status;
-- (void) sync:(NSString*)url onLocationThreshold:(NSInteger)threshold;
+- (void) sync:(NSString*)url onLocationThreshold:(NSInteger)threshold withHttpHeaders: (NSMutableDictionary*)httpHeaders;
 - (void) cancel;
 
 @end

--- a/ios/CDVBackgroundGeolocation/LocationUploader.m
+++ b/ios/CDVBackgroundGeolocation/LocationUploader.m
@@ -55,7 +55,7 @@
     }
 }
 
-- (void) sync:(NSString*)url onLocationThreshold:(NSInteger)threshold;
+- (void) sync:(NSString*)url onLocationThreshold:(NSInteger)threshold withHttpHeaders: (NSMutableDictionary*)httpHeaders;
 {
     SQLiteLocationDAO* locationDAO = [SQLiteLocationDAO sharedInstance];
     NSNumber *locationsCount = [locationDAO getLocationsCount];
@@ -85,7 +85,12 @@
     [request setHTTPMethod:@"POST"];
     [request setValue:[NSString stringWithFormat:@"%llu", bytesTotalForThisFile] forHTTPHeaderField:@"Content-Length"];
     [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
-    
+    if (httpHeaders != nil) {
+        for(id key in httpHeaders) {
+            id value = [httpHeaders objectForKey:key];
+            [request addValue:value forHTTPHeaderField:key];
+        }
+    }
     NSURLSessionTask *task = [urlSession uploadTaskWithRequest:request fromFile:jsonUrl];
     task.taskDescription = fileName;
     [tasks addObject:task];


### PR DESCRIPTION
I found a same problem with [Issue #308 ](https://github.com/mauron85/cordova-plugin-background-geolocation/issues/308).

So, I fix sync method to be able to add httpHeaders.