### PR TITLE
Update location message configuration

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -160,6 +160,9 @@
         <!-- required background modes:  App registers for location updates -->
         <preference name="ALWAYS_USAGE_DESCRIPTION" default="This app always requires location tracking" />
 
+        <config-file target="*-Info.plist" parent="NSLocationAlwaysUsageDescription">
+            <string>$ALWAYS_USAGE_DESCRIPTION</string>
+        </config-file>
         <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
             <string>$ALWAYS_USAGE_DESCRIPTION</string>
         </config-file>

--- a/plugin.xml
+++ b/plugin.xml
@@ -158,8 +158,12 @@
 
     <platform name="ios">
         <!-- required background modes:  App registers for location updates -->
-        <preference name="ALWAYS_USAGE_DESCRIPTION" default="This app requires background location tracking" />
-        <config-file target="*-Info.plist" parent="NSLocationAlwaysUsageDescription">
+        <preference name="ALWAYS_USAGE_DESCRIPTION" default="This app always requires location tracking" />
+
+        <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
+            <string>$ALWAYS_USAGE_DESCRIPTION</string>
+        </config-file>
+        <config-file target="*-Info.plist" parent="NSLocationAlwaysAndWhenInUseUsageDescription">
             <string>$ALWAYS_USAGE_DESCRIPTION</string>
         </config-file>
 


### PR DESCRIPTION
Drop NSLocationAlwaysUsageDescription in favour of NSLocationWhenInUseUsageDescription and NSLocationAlwaysAndWhenInUseUsageDescription

I was seeing the following message in the debug window in Xcode

    This app has attempted to access privacy-sensitive data without a usage description. 
    The app's Info.plist must contain both NSLocationAlwaysAndWhenInUseUsageDescription 
    and NSLocationWhenInUseUsageDescription keys with string values explaining to the user 
    how the app uses this data

Switching to `NSLocationWhenInUseUsageDescription` and `NSLocationAlwaysAndWhenInUseUsageDescription` resolves the issue.