### PR TITLE
Make account name configurable.

### DIFF
--- a/android/plugin/src/main/java/com/marianhello/bgloc/Config.java
+++ b/android/plugin/src/main/java/com/marianhello/bgloc/Config.java
@@ -31,6 +31,7 @@ public class Config implements Parcelable
     public static final int ANDROID_ACTIVITY_PROVIDER = 1;
 
     // actual values should be read from strings.xml
+    public static final String ACCOUNT_NAME_RESOURCE = "account_name";
     public static final String ACCOUNT_TYPE_RESOURCE = "account_type";
     public static final String CONTENT_AUTHORITY_RESOURCE = "content_authority";
 

--- a/android/plugin/src/main/java/com/marianhello/bgloc/LocationService.java
+++ b/android/plugin/src/main/java/com/marianhello/bgloc/LocationService.java
@@ -175,7 +175,9 @@ public class LocationService extends Service {
 
         dao = (DAOFactory.createLocationDAO(this));
         syncAccount = AccountHelper.CreateSyncAccount(this,
-                AuthenticatorService.getAccount(getStringResource(Config.ACCOUNT_TYPE_RESOURCE)));
+                AuthenticatorService.getAccount(
+                    getStringResource(Config.ACCOUNT_NAME_RESOURCE),
+                    getStringResource(Config.ACCOUNT_TYPE_RESOURCE)));
 
         registerReceiver(connectivityChangeReceiver, new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
     }

--- a/android/plugin/src/main/java/com/marianhello/bgloc/sync/AuthenticatorService.java
+++ b/android/plugin/src/main/java/com/marianhello/bgloc/sync/AuthenticatorService.java
@@ -6,7 +6,6 @@ import android.content.Intent;
 import android.os.IBinder;
 
 public class AuthenticatorService extends Service {
-    public static final String ACCOUNT_NAME = "dummy";
 
     private Authenticator mAuthenticator;
 
@@ -29,7 +28,7 @@ public class AuthenticatorService extends Service {
     }
 
 
-    public static Account getAccount(String accountType) {
-        return new Account(ACCOUNT_NAME, accountType);
+    public static Account getAccount(String accountName, String accountType) {
+        return new Account(accountName, accountType);
     }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,6 +21,7 @@
     <platform name="android">
         <preference name="ICON" default="@mipmap/icon" />
         <preference name="SMALL_ICON" default="@mipmap/icon" />
+        <preference name="ACCOUNT_NAME" default="@string/app_name" />
         <preference name="ACCOUNT_LABEL" default="@string/app_name" />
         <preference name="ACCOUNT_TYPE" default="$PACKAGE_NAME.account" />
         <preference name="CONTENT_AUTHORITY" default="$PACKAGE_NAME" />
@@ -131,6 +132,7 @@
         </config-file>
 
         <config-file target="res/values/strings.xml" parent="/resources">
+            <string name="account_name">$ACCOUNT_NAME</string>
             <string name="account_type">$ACCOUNT_TYPE</string>
             <string name="content_authority">$CONTENT_AUTHORITY</string>
         </config-file>


### PR DESCRIPTION
This change adds the ability to customize the account name that can be shown when navigating to "Settings -> Accounts -> My App", which before this change, would show "dummy" ass the account title. This defaults that to the name of the app "My App", with the ability to customize from `config.xml`.

Addresses #331 

Please let me know if there is something different I should be doing for this. It works in my case, but I'm relatively new to Cordova plugin development.
