### PR TITLE
Detect Fake provider and has mock location to old Android

### DIFF
--- a/android/CDVBackgroundGeolocation/src/main/java/com/tenforwardconsulting/bgloc/cordova/BackgroundGeolocationPlugin.java
+++ b/android/CDVBackgroundGeolocation/src/main/java/com/tenforwardconsulting/bgloc/cordova/BackgroundGeolocationPlugin.java
@@ -66,6 +66,14 @@ public class BackgroundGeolocationPlugin extends CordovaPlugin implements Plugin
     public static final String ACTION_REGISTER_EVENT_LISTENER = "addEventListener";
     public static final String ACTION_START_TASK = "startTask";
     public static final String ACTION_END_TASK = "endTask";
+    public static Context staticContext;
+    public static Boolean hasMockLocationsEnabled() {
+        if (staticContext != null) {
+            return android.provider.Settings.Secure.getString(staticContext.getContentResolver(), android.provider.Settings.Secure.ALLOW_MOCK_LOCATION).equals("1");
+        }
+        return false;
+    }
+
 
     private static final int PERMISSIONS_REQUEST_CODE = 1;
 
@@ -86,6 +94,7 @@ public class BackgroundGeolocationPlugin extends CordovaPlugin implements Plugin
 
     public boolean execute(String action, final JSONArray data, final CallbackContext callbackContext) {
         Context context = getContext();
+        staticContext = context;
 
         if (ACTION_REGISTER_EVENT_LISTENER.equals(action)) {
             logger.debug("Registering event listeners");


### PR DESCRIPTION
Hi,

For our project, and we think for a lot of project, it is very interested know in the location is real or it is fake.

For this issue, only for Android devices, we use theree methods:

1. The location is from mock provider (for new Android devices)
2. The mock location is enabled in developer settings  (for old Android devices)
3. You have installed a list of several fake apps.

We think the first point and second would be very useful is they were included in your plugin. 

I'm sory if the PR is not very clean.

Included this commit too:
https://github.com/goinnn/background-geolocation-android/commit/5e839275973d9e9e1d2ae9cbfcf926927336aca7