### PR TITLE
Removed non public URL

### DIFF
--- a/ios/CDVBackgroundGeolocation/LocationManager.m
+++ b/ios/CDVBackgroundGeolocation/LocationManager.m
@@ -312,7 +312,8 @@ enum {
 
 - (void) showLocationSettings
 {
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"prefs:root=LOCATION_SERVICES"]];
+    // NOOP - Since Apple started rejecting apps using non public url schemes
+    // https://github.com/mauron85/cordova-plugin-background-geolocation/issues/394
 }
 
 - (NSMutableDictionary*) getStationaryLocation

--- a/plugin.xml
+++ b/plugin.xml
@@ -182,19 +182,6 @@
             </array>
         </config-file>
 
-        <config-file target="*-Info.plist" parent="CFBundleURLTypes">
-            <array>
-              <dict>
-                <key>CFBundleTypeRole</key>
-                <string>Editor</string>
-                <key>CFBundleURLSchemes</key>
-                <array>
-                  <string>prefs</string>
-                </array>
-              </dict>
-            </array>
-        </config-file>
-
         <config-file target="config.xml" parent="/*">
             <feature name="BackgroundGeolocation">
                 <param name="ios-package" value="CDVBackgroundGeolocation" />


### PR DESCRIPTION
Emptied the showLocationSettings() to remove the non public url scheme.

Fix for issue https://github.com/mauron85/cordova-plugin-background-geolocation/issues/394 on the 2.x branch. 