### PR TITLE
Foreground service permission is required since Android 28 #623.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -176,6 +176,7 @@
             <uses-permission android:name="android.permission.ACCESS_LOCATION_EXTRA_COMMANDS" />
             <uses-permission android:name="android.permission.INTERNET" />
             <uses-permission android:name="android.permission.WAKE_LOCK" />
+            <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
             <uses-permission android:name="android.hardware.location" />
         </config-file>
         <config-file target="res/xml/config.xml" parent="/*">


### PR DESCRIPTION
Added relevant permissions to plugin.xml file.