### PR TITLE
fixed notification handler override

### DIFF
--- a/ios/CDVBackgroundGeolocation/CDVBackgroundGeolocation.m
+++ b/ios/CDVBackgroundGeolocation/CDVBackgroundGeolocation.m
@@ -448,12 +448,7 @@ static NSString * const TAG = @"CDVBackgroundGeolocation";
  * on UIApplicationDidFinishLaunchingNotification
  */
 -(void) onFinishLaunching:(NSNotification *)notification
-{
-    if (@available(iOS 10, *)) {
-        UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-        center.delegate = self;
-    }
-    
+{   
     NSDictionary *dict = [notification userInfo];
 
     MAURConfig *config = [facade getConfig];


### PR DESCRIPTION
fix for issues #627 and #682 . The notification center override show only happened when in debugging mode; otherwise it interferes with the push notification mechanism. The code for the debugging is already there, so removing unnecessary duplicate code causing the issue. 