### PR TITLE
Fix wrong plugin id

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### [3.1.1] - 2021-03-23
+### Fixed
+- fix wrong plugin id 
+
 ### [3.1.0] - 2019-09-24
 ### Fixed
 - fix package scope

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mauron85/cordova-plugin-background-geolocation",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Cordova Background Geolocation Plugin",
   "main": "./www/BackgroundGeolocation.js",
   "types": "./www/BackgroundGeolocation.d.ts",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,8 +2,8 @@
 
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
-        id="cordova-plugin-background-geolocation"
-        version="3.1.0">
+        id="@mauron85/cordova-plugin-background-geolocation"
+        version="3.1.1">
     <name>CDVBackgroundGeolocation</name>
     <description>Cordova Background Geolocation Plugin</description>
     <license>Apache-2.0</license>


### PR DESCRIPTION
This wrong plugin id is breaking build, by installing some old plugins named: `cordova-plugin-background-geolocation`